### PR TITLE
Format link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The design, unless otherwise specified, is released under the CERN Open Source Hardware License version 2 permissive variant, CERN-OHL-P. A copy of the license is provided in the source repository. Additionally, user guide of the license is provided on ohwr.org. Specifically, the core design (caster.v as top level) is entirely licensed under CERN-OHL-P.
 
-Part of the board level RTL design is adapted from Gaurav Singh www.circuitvalley.com's MIPI CSI-2 receiver design, which is licensed under CC BY 3.0 and CC BY 4.0.
+Part of the board level RTL design is adapted from [Gaurav Singh](https://www.circuitvalley.com)'s MIPI CSI-2 receiver design, which is licensed under CC BY 3.0 and CC BY 4.0.
 
 The I2C master implementation, which is part of the board level RTL design, is adapted from github.com chance189/I2C_Master.
 


### PR DESCRIPTION
Use a formatted link in the `README.md` Markdown (Github autodetected link formatting is broken).